### PR TITLE
Shuffle mode

### DIFF
--- a/Midibard/Control/MidiControl/MidiPlayerControl.cs
+++ b/Midibard/Control/MidiControl/MidiPlayerControl.cs
@@ -141,16 +141,19 @@ internal static class MidiPlayerControl
 
 	}
 
+	internal static void ClearAlreadyPlayed(){
+		playedIndexes.Clear();
+	}
 
 	// Takes in the set of already played songs and returns a new random song that hasn't already been played.
 
 	// @TODO so i don't forget, need to add a function so pressing the play button resets the playedlist, or add another button there since there is room in the UI
-	private static int limitedRandom(HashSet<int> playedIndexes)
+	private static int LimitedRandom(HashSet<int> playedIndexes)
 	{
 		//we've played all the songs, reset.
 		if(playedIndexes.Count == PlaylistManager.FilePathList.Count)
 		{
-			playedIndexes.Clear(); 
+			ClearAlreadyPlayed();
 		}
 
 		var unplayed = Enumerable.Range(0, PlaylistManager.FilePathList.Count-1).Where(i => !playedIndexes.Contains(i));
@@ -186,7 +189,7 @@ internal static class MidiPlayerControl
 				var r = new Random();
 				do
 				{
-					songIndex = limitedRandom(playedIndexes);
+					songIndex = LimitedRandom(playedIndexes);
 					playedIndexes.Add(songIndex);
 				} while (songIndex == PlaylistManager.CurrentSongIndex);
 			}

--- a/Midibard/Control/MidiControl/MidiPlayerControl.cs
+++ b/Midibard/Control/MidiControl/MidiPlayerControl.cs
@@ -140,14 +140,12 @@ internal static class MidiPlayerControl
 		PlaylistManager.LoadPlayback(songIndex, MidiBard.IsPlaying);
 
 	}
-
+	
 	internal static void ClearAlreadyPlayed(){
 		playedIndexes.Clear();
 	}
 
 	// Takes in the set of already played songs and returns a new random song that hasn't already been played.
-
-	// @TODO so i don't forget, need to add a function so pressing the play button resets the playedlist, or add another button there since there is room in the UI
 	private static int LimitedRandom(HashSet<int> playedIndexes)
 	{
 		//we've played all the songs, reset.

--- a/Midibard/Managers/PlaylistManager.cs
+++ b/Midibard/Managers/PlaylistManager.cs
@@ -147,6 +147,8 @@ static class PlaylistManager
 		var success = 0;
 		var sw = Stopwatch.StartNew();
 
+		MidiPlayerControl.ClearAlreadyPlayed();
+
 		await Task.Run(() => {
 			foreach (var path in CheckValidFiles(filePaths)) {
 				FilePathList.Add(new SongEntry { FilePath = path });

--- a/Midibard/Managers/PlaylistManager.cs
+++ b/Midibard/Managers/PlaylistManager.cs
@@ -95,6 +95,7 @@ static class PlaylistManager
 	public static void Clear()
 	{
 		FilePathList.Clear();
+		MidiPlayerControl.ClearAlreadyPlayed();
 		CurrentSongIndex = -1;
 		IPCHandles.SyncPlaylist();
 	}
@@ -113,6 +114,7 @@ static class PlaylistManager
 		try {
 			FilePathList.RemoveAt(index);
 			PluginLog.Debug($"removed [{playlistIndex}, {index}]");
+			MidiPlayerControl.ClearAlreadyPlayed();
 			if (index < CurrentSongIndex) {
 				CurrentSongIndex--;
 			}


### PR DESCRIPTION
Converts the current random song selection to a shuffle mode implementation. eg, the same song won't play twice until the playlist is complete.  Implemented via tracking a list of already played song indices that are reset when the playlist is modified.