### PR TITLE
Fix log spam if party member disconnects

### DIFF
--- a/Midibard/Managers/PartyWatcher.cs
+++ b/Midibard/Managers/PartyWatcher.cs
@@ -18,6 +18,7 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Windows.Documents;
 using Dalamud.Plugin.Services;
 using static Dalamud.api;
 
@@ -30,17 +31,32 @@ public class PartyWatcher : IDisposable
         api.Framework.Update += Framework_Update;
     }
 
-    public long[] PartyMemberCIDs { get; private set; } = { };
+    public long[] PartyMemberCIDs { get; private set; } = Array.Empty<long>();
 
-    public static long[] GetMemberCIDs => api.PartyList
-        .Where(i => i.World.Value.RowId > 0 && i.Territory.Value.RowId > 0)
-        .Select(i => i.ContentId)
-        .ToArray();
+    public static long[] GetMemberCIDs()
+    {
+        System.Collections.Generic.List<long> cids = new();
+        foreach(var p in api.PartyList)
+        {
+            try
+            {
+                if (p.ObjectId <= 0 || !p.GameObject.IsValid())
+                    continue;
+                if (p.World.Value.RowId > 0 && p.Territory.Value.RowId > 0)
+                {
+                    cids.Add(p.ContentId);
+                }
+            }
+            catch (NullReferenceException) { }
+        }
+        return cids.ToArray();
+
+    }
 
     [SuppressMessage("ReSharper", "SimplifyLinqExpressionUseAll")]
     private void Framework_Update(IFramework framework)
     {
-        var newMemberCIDs = GetMemberCIDs;
+        var newMemberCIDs = GetMemberCIDs();
         if (!newMemberCIDs.ToHashSet().SetEquals(PartyMemberCIDs.ToHashSet()))
         {
             //PluginLog.Warning($"CHANGE {newList.Length - PartyMembers.Length}");

--- a/Midibard/Managers/PartyWatcher.cs
+++ b/Midibard/Managers/PartyWatcher.cs
@@ -18,7 +18,6 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-using System.Windows.Documents;
 using Dalamud.Plugin.Services;
 using static Dalamud.api;
 

--- a/Midibard/MidiBard.cs
+++ b/Midibard/MidiBard.cs
@@ -43,7 +43,6 @@ using MidiBard.Util.Lyrics;
 using MidiBard2.IPC;
 using static Dalamud.api;
 using Dalamud.Utility;
-using FFXIVClientStructs.FFXIV.Client.UI.Agent;
 
 namespace MidiBard;
 
@@ -124,8 +123,8 @@ public class MidiBard : IDalamudPlugin
         //GuitarTonePatch.InitAndApply();
 
         var raptureAtkModule = FFXIVClientStructs.FFXIV.Client.System.Framework.Framework.Instance()->UIModule->GetRaptureAtkModule();
-        var pAgentPerformanceMetronome = raptureAtkModule->AgentModule.GetAgentByInternalId(AgentId.PerformanceMetronome);
-        var pAgentPerformance = raptureAtkModule->AgentModule.GetAgentByInternalId(AgentId.PerformanceMode);
+        var pAgentPerformanceMetronome = raptureAtkModule->AgentModule.GetAgentByInternalId(FFXIVClientStructs.FFXIV.Client.UI.Agent.AgentId.PerformanceMetronome);
+        var pAgentPerformance = raptureAtkModule->AgentModule.GetAgentByInternalId(FFXIVClientStructs.FFXIV.Client.UI.Agent.AgentId.PerformanceMode);
 
         AgentMetronome = new AgentMetronome((IntPtr)pAgentPerformanceMetronome);
         AgentPerformance = new AgentPerformance((IntPtr)pAgentPerformance);


### PR DESCRIPTION
Not sure if PartyWatcher is used anywhere, but updated to handle changes to Lumina in API11. .IsValid() should keep it from checking bad player objects, while the exception catch prevents the log spam in other cases.