### PR TITLE
Remove pause at the beginning for non aligned songs

### DIFF
--- a/Midibard/Control/CharacterControl/SwitchInstrument.cs
+++ b/Midibard/Control/CharacterControl/SwitchInstrument.cs
@@ -134,15 +134,12 @@ internal static class SwitchInstrument
 	public static bool TryParseInstrumentName(string capturedInstrumentString, out uint instrumentId)
     {
         var bmpNameEqual = TrackInfo.GetInstrumentIDByName(capturedInstrumentString);
-		Perform? equal = MidiBard.InstrumentSheet.FirstOrDefault(i =>
-			i.Instrument.ExtractText().Equals(capturedInstrumentString, StringComparison.InvariantCultureIgnoreCase) == true);
-		Perform? contains = MidiBard.InstrumentSheet.FirstOrDefault(i =>
-            i.Instrument.ExtractText().ContainsIgnoreCase(capturedInstrumentString) == true);
-		Perform? gmName = MidiBard.InstrumentSheet.FirstOrDefault(i =>
-            i.Instrument.ExtractText().ContainsIgnoreCase(capturedInstrumentString) == true);
-
-		var rowId = bmpNameEqual ?? (equal ?? contains ?? gmName)?.RowId;
-		PluginLog.Debug($"idFromBmpName: {bmpNameEqual}, equal: {equal?.Instrument.ExtractText()}, contains: {contains?.Instrument.ExtractText()}, gmName: {gmName?.Name.ExtractText()} finalId: {rowId}");
+		string lookupstr = capturedInstrumentString.ToLower().Trim(); //trim it, lower it, make it working
+        Perform? sheet = MidiBard.InstrumentSheet.FirstOrDefault(i => i.GetGameProgramName().ContainsIgnoreCase(lookupstr) ||
+																	 i.GetGameProgramName().StartsWith(lookupstr) ||
+                                                                     i.GetGameProgramName().Equals(lookupstr, StringComparison.Ordinal) );
+		var rowId = bmpNameEqual ?? sheet?.RowId;
+		PluginLog.Debug($"idFromBmpName: {bmpNameEqual}, equal: {sheet?.GetGameProgramName()}, finalId: {rowId}");
 		if (rowId is null)
 		{
 			instrumentId = 0;

--- a/Midibard/Control/MidiControl/PlaybackInstance/BardPlayback.cs
+++ b/Midibard/Control/MidiControl/PlaybackInstance/BardPlayback.cs
@@ -131,7 +131,8 @@ internal sealed class BardPlayback : Playback
 
 	private static void PreparePlaybackData(MidiFile file, out TempoMap tempoMap, out TrackChunk[] trackChunks, out TrackInfo[] trackInfos, out TimedEventWithMetadata[] timedEventWithMetadata)
 	{
-		tempoMap = TryGetTempoNap(file);
+		file = MidiPreprocessor.RealignMidiFile(file);
+        tempoMap = TryGetTempoNap(file);
 		var map = tempoMap;
 		trackChunks = MidiPreprocessor.ProcessTracks(GetNoteTracks(file).ToArray(), map);
 		trackInfos = trackChunks.Select((chunk, index) => GetTrackInfos(chunk, index, map)).ToArray();


### PR DESCRIPTION
This will remove the pause at the beginning of some songs and fix the instruments by filename function.
Helps to get rid of the awkward silence before a song starts to play, same function I'm using to 0 align the songs.