### PR TITLE
Add Linux support for compilation and do IPC via TCP if not in Windows

### DIFF
--- a/Midibard/IPC/IIPCTransport.cs
+++ b/Midibard/IPC/IIPCTransport.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Threading.Tasks;
+
+namespace MidiBard.IPC;
+
+public interface IIPCTransport : IDisposable
+{
+    event EventHandler<MessageReceivedEventArgs> MessageReceived;
+    Task<bool> PublishAsync(byte[] message);
+    bool IsInitialized { get; }
+}
+
+public class MessageReceivedEventArgs : EventArgs
+{
+    public byte[] Message { get; set; }
+
+    public MessageReceivedEventArgs(byte[] message)
+    {
+        Message = message;
+    }
+}
+
+public class NullIPCTransport : IIPCTransport
+{
+    public event EventHandler<MessageReceivedEventArgs> MessageReceived;
+    public bool IsInitialized => false;
+
+    public Task<bool> PublishAsync(byte[] message)
+    {
+        return Task.FromResult(false);
+    }
+
+    public void Dispose()
+    {
+    }
+}

--- a/Midibard/IPC/IPCManager.cs
+++ b/Midibard/IPC/IPCManager.cs
@@ -25,9 +25,6 @@ using System.Threading;
 
 using MidiBard.Util;
 
-using TinyIpc.IO;
-using TinyIpc.Messaging;
-
 using static Dalamud.api;
 
 namespace MidiBard.IPC;
@@ -36,7 +33,7 @@ internal class IPCManager : IDisposable
 {
     private readonly bool initFailed;
     private bool _messagesQueueRunning = true;
-    private readonly TinyMessageBus MessageBus;
+    private readonly IIPCTransport _transport;
     private readonly ConcurrentQueue<(byte[] serialized, bool includeSelf)> messageQueue = new();
     private readonly AutoResetEvent _autoResetEvent = new(false);
     private readonly Dictionary<MessageTypeCode, Action<IPCEnvelope>> _methodInfos;
@@ -44,9 +41,15 @@ internal class IPCManager : IDisposable
     {
         try
         {
-            const long maxFileSize = 1 << 24;
-            MessageBus = new TinyMessageBus(new TinyMemoryMappedFile("Midibard.IPC", maxFileSize), true);
-            MessageBus.MessageReceived += MessageBus_MessageReceived;
+            _transport = CreateTransport();
+            if (_transport.IsInitialized)
+            {
+                _transport.MessageReceived += Transport_MessageReceived;
+            }
+            else
+            {
+                throw new InvalidOperationException("Transport initialization failed");
+            }
 
             _methodInfos = typeof(IPCHandles)
                 .GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)
@@ -68,15 +71,16 @@ internal class IPCManager : IDisposable
                             var message = dequeue.serialized;
                             var messageLength = message.Length;
                             PluginLog.Verbose($"Dequeue serialized. length: {Dalamud.Utility.Util.FormatBytes(messageLength)}");
+                            const long maxFileSize = 1 << 24;
                             if (messageLength > maxFileSize)
                             {
-                                throw new InvalidOperationException($"Message size is too large! TinyIpc will crash when handling this, not gonna let it through. maxFileSize: {Dalamud.Utility.Util.FormatBytes(maxFileSize)}");
+                                throw new InvalidOperationException($"Message size is too large! IPC will crash when handling this, not gonna let it through. maxFileSize: {Dalamud.Utility.Util.FormatBytes(maxFileSize)}");
                             }
 
-                            if (MessageBus.PublishAsync(message).Wait(5000))
+                            if (_transport.PublishAsync(message).Wait(5000))
                             {
                                 PluginLog.Verbose($"Message published.");
-                                if (dequeue.includeSelf) MessageBus_MessageReceived(null, new TinyMessageReceivedEventArgs(message));
+                                if (dequeue.includeSelf) Transport_MessageReceived(null, new MessageReceivedEventArgs(message));
                             }
                             else
                             {
@@ -98,24 +102,24 @@ internal class IPCManager : IDisposable
         }
         catch (PlatformNotSupportedException e)
         {
-            PluginLog.Error(e, $"TinyIpc init failed. Unfortunately TinyIpc is not available on Linux. local ensemble sync will not function properly.");
+            PluginLog.Error(e, $"IPC transport init failed. Platform not supported. local ensemble sync will not function properly.");
             initFailed = true;
         }
         catch (Exception e)
         {
-            PluginLog.Error(e, $"TinyIpc init failed. local ensemble sync will not function properly.");
+            PluginLog.Error(e, $"IPC transport init failed. local ensemble sync will not function properly.");
             initFailed = true;
         }
     }
 
-    private void MessageBus_MessageReceived(object sender, TinyMessageReceivedEventArgs e)
+    private void Transport_MessageReceived(object sender, MessageReceivedEventArgs e)
     {
         if (initFailed) return;
         try
         {
             var sw = Stopwatch.StartNew();
             PluginLog.Verbose($"message received");
-            var bytes = e.Message.ToArray<byte>().Decompress();
+            var bytes = e.Message.Decompress();
             PluginLog.Verbose($"message decompressed in {sw.Elapsed.TotalMilliseconds}ms");
             var message = bytes.ProtoDeserialize<IPCEnvelope>();
             PluginLog.Verbose($"proto deserialized in {sw.Elapsed.TotalMilliseconds}ms");
@@ -155,7 +159,11 @@ internal class IPCManager : IDisposable
         try
         {
             _messagesQueueRunning = false;
-            MessageBus.MessageReceived -= MessageBus_MessageReceived;
+            if (_transport != null)
+            {
+                _transport.MessageReceived -= Transport_MessageReceived;
+                _transport.Dispose();
+            }
             if (initFailed) return;
             _autoResetEvent?.Set();
             _autoResetEvent?.Dispose();
@@ -179,5 +187,17 @@ internal class IPCManager : IDisposable
     ~IPCManager()
     {
         ReleaseUnmanagedResources(false);
+    }
+
+    private static IIPCTransport CreateTransport()
+    {
+        if (WineDetector.IsRunningUnderWine || WineDetector.IsLinuxEnvironment)
+        {
+            PluginLog.Warning("Wine/Linux environment detected - TCP transport not yet implemented, using null transport");
+            return new NullIPCTransport();
+        }
+
+        PluginLog.Information("Windows environment detected - using TinyIPC transport");
+        return new TinyIPCTransport();
     }
 }

--- a/Midibard/IPC/IPCManager.cs
+++ b/Midibard/IPC/IPCManager.cs
@@ -193,8 +193,8 @@ internal class IPCManager : IDisposable
     {
         if (WineDetector.IsRunningUnderWine || WineDetector.IsLinuxEnvironment)
         {
-            PluginLog.Warning("Wine/Linux environment detected - TCP transport not yet implemented, using null transport");
-            return new NullIPCTransport();
+            PluginLog.Information("Wine/Linux environment detected - using TCP transport");
+            return new TCPIPCTransport(MidiBard.config.TCPIPCPort);
         }
 
         PluginLog.Information("Windows environment detected - using TinyIPC transport");

--- a/Midibard/IPC/TCPIPCTransport.cs
+++ b/Midibard/IPC/TCPIPCTransport.cs
@@ -1,0 +1,281 @@
+using System;
+using System.Collections.Concurrent;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+
+using static Dalamud.api;
+
+namespace MidiBard.IPC;
+
+internal class TCPIPCTransport : IIPCTransport
+{
+    private readonly int _port;
+    private readonly ConcurrentDictionary<string, TcpClient> _clients = new();
+    private TcpListener _server;
+    private readonly CancellationTokenSource _cancellationTokenSource;
+    private bool _disposed;
+
+    public event EventHandler<MessageReceivedEventArgs> MessageReceived;
+    public bool IsInitialized { get; private set; }
+
+    public TCPIPCTransport(int port = 21043)
+    {
+        _port = FindAvailablePort(port);
+        _cancellationTokenSource = new CancellationTokenSource();
+
+        try
+        {
+            InitializeServer();
+            ConnectToExistingInstances();
+            IsInitialized = true;
+            PluginLog.Information($"TCP transport initialized successfully on port {_port}");
+        }
+        catch (Exception e)
+        {
+            PluginLog.Error(e, $"Failed to initialize TCP transport on port {_port}");
+            IsInitialized = false;
+        }
+    }
+
+    private void InitializeServer()
+    {
+        _server = new TcpListener(IPAddress.Loopback, _port);
+        _server.Start();
+
+        // Start accepting connections
+        _ = Task.Run(async () =>
+        {
+            while (!_cancellationTokenSource.Token.IsCancellationRequested)
+            {
+                try
+                {
+                    var tcpClient = await _server.AcceptTcpClientAsync();
+                    var clientId = tcpClient.Client.RemoteEndPoint.ToString();
+                    _clients[clientId] = tcpClient;
+
+                    PluginLog.Debug($"TCP client connected: {clientId}");
+
+                    // Handle client messages
+                    _ = Task.Run(() => HandleClientMessages(tcpClient, clientId), _cancellationTokenSource.Token);
+                }
+                catch (ObjectDisposedException)
+                {
+                    // Server was disposed, exit gracefully
+                    break;
+                }
+                catch (Exception e)
+                {
+                    PluginLog.Error(e, "Error accepting TCP client connection");
+                }
+            }
+        }, _cancellationTokenSource.Token);
+    }
+
+
+    private async Task HandleClientMessages(TcpClient client, string clientId)
+    {
+        try
+        {
+            var stream = client.GetStream();
+            var buffer = new byte[4]; // For message length prefix
+
+            while (!_cancellationTokenSource.Token.IsCancellationRequested && client.Connected)
+            {
+                // Read message length (4 bytes)
+                int bytesRead = 0;
+                while (bytesRead < 4)
+                {
+                    int read = await stream.ReadAsync(buffer, bytesRead, 4 - bytesRead, _cancellationTokenSource.Token);
+                    if (read == 0)
+                    {
+                        // Client disconnected
+                        return;
+                    }
+                    bytesRead += read;
+                }
+
+                int messageLength = BitConverter.ToInt32(buffer, 0);
+                if (messageLength <= 0 || messageLength > (1 << 24)) // Max 16MB message
+                {
+                    PluginLog.Warning($"Invalid message length received from {clientId}: {messageLength}");
+                    continue;
+                }
+
+                // Read message payload
+                var messageBuffer = new byte[messageLength];
+                bytesRead = 0;
+                while (bytesRead < messageLength)
+                {
+                    int read = await stream.ReadAsync(messageBuffer, bytesRead, messageLength - bytesRead, _cancellationTokenSource.Token);
+                    if (read == 0)
+                    {
+                        // Client disconnected
+                        return;
+                    }
+                    bytesRead += read;
+                }
+
+                // Process all received messages (echo prevention handled at application level)
+                MessageReceived?.Invoke(this, new MessageReceivedEventArgs(messageBuffer));
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Expected during shutdown
+        }
+        catch (Exception e)
+        {
+            PluginLog.Error(e, $"Error handling messages from TCP client {clientId}");
+        }
+        finally
+        {
+            // Clean up client connection
+            _clients.TryRemove(clientId, out _);
+            client?.Close();
+            PluginLog.Debug($"TCP client disconnected: {clientId}");
+        }
+    }
+
+    public async Task<bool> PublishAsync(byte[] message)
+    {
+        if (!IsInitialized || _disposed) return false;
+
+        try
+        {
+            var messageLength = BitConverter.GetBytes(message.Length);
+            var success = false;
+
+            // Send to all connected clients
+            foreach (var kvp in _clients)
+            {
+                var client = kvp.Value;
+                if (client.Connected)
+                {
+                    try
+                    {
+                        var stream = client.GetStream();
+                        await stream.WriteAsync(messageLength, 0, 4, _cancellationTokenSource.Token);
+                        await stream.WriteAsync(message, 0, message.Length, _cancellationTokenSource.Token);
+                        await stream.FlushAsync(_cancellationTokenSource.Token);
+                        success = true;
+                    }
+                    catch (Exception e)
+                    {
+                        PluginLog.Error(e, $"Error sending message to TCP client {kvp.Key}");
+                        // Remove disconnected client
+                        _clients.TryRemove(kvp.Key, out _);
+                        client?.Close();
+                    }
+                }
+            }
+
+            return success;
+        }
+        catch (Exception e)
+        {
+            PluginLog.Error(e, "Error publishing message via TCP transport");
+            return false;
+        }
+    }
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+
+        _disposed = true;
+
+        try
+        {
+            _cancellationTokenSource?.Cancel();
+
+            // Close all client connections
+            foreach (var client in _clients.Values)
+            {
+                client?.Close();
+            }
+            _clients.Clear();
+
+            // Stop the server
+            _server?.Stop();
+
+            _cancellationTokenSource?.Dispose();
+        }
+        catch (Exception e)
+        {
+            PluginLog.Error(e, "Error disposing TCP transport");
+        }
+
+        GC.SuppressFinalize(this);
+    }
+
+    private int FindAvailablePort(int startPort)
+    {
+        for (int port = startPort; port < startPort + 100; port++)
+        {
+            if (IsPortAvailable(port))
+            {
+                return port;
+            }
+        }
+
+        // If no port is available in the range, use the original port and let it fail
+        PluginLog.Warning($"No available ports found in range {startPort}-{startPort + 100}, using {startPort}");
+        return startPort;
+    }
+
+    private bool IsPortAvailable(int port)
+    {
+        try
+        {
+            using var listener = new TcpListener(IPAddress.Loopback, port);
+            listener.Start();
+            listener.Stop();
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private void ConnectToExistingInstances()
+    {
+        // Try to connect to other instances running on nearby ports
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                int basePort = _port - (_port % 100); // Round down to nearest 100
+                int maxPort = basePort + 100;
+
+                for (int port = basePort; port < maxPort; port++)
+                {
+                    if (port == _port) continue; // Skip our own port
+
+                    try
+                    {
+                        var client = new TcpClient();
+                        await client.ConnectAsync(IPAddress.Loopback, port);
+                        var clientId = $"instance-{port}";
+                        _clients[clientId] = client;
+
+                        PluginLog.Debug($"Connected to existing TCP instance: {clientId}");
+
+                        // Handle messages from this instance
+                        _ = Task.Run(() => HandleClientMessages(client, clientId), _cancellationTokenSource.Token);
+                    }
+                    catch
+                    {
+                        // Port not available or no server running, continue
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                PluginLog.Error(e, "Error connecting to existing TCP instances");
+            }
+        }, _cancellationTokenSource.Token);
+    }
+}

--- a/Midibard/IPC/TinyIPCTransport.cs
+++ b/Midibard/IPC/TinyIPCTransport.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+
+using TinyIpc.IO;
+using TinyIpc.Messaging;
+
+using static Dalamud.api;
+
+namespace MidiBard.IPC;
+
+internal class TinyIPCTransport : IIPCTransport
+{
+    private readonly TinyMessageBus _messageBus;
+    private bool _disposed;
+
+    public event EventHandler<MessageReceivedEventArgs> MessageReceived;
+    public bool IsInitialized { get; private set; }
+
+    public TinyIPCTransport()
+    {
+        try
+        {
+            const long maxFileSize = 1 << 24;
+            _messageBus = new TinyMessageBus(new TinyMemoryMappedFile("Midibard.IPC", maxFileSize), true);
+            _messageBus.MessageReceived += OnTinyMessageReceived;
+            IsInitialized = true;
+            PluginLog.Information("TinyIPC transport initialized successfully");
+        }
+        catch (Exception e)
+        {
+            PluginLog.Error(e, "Failed to initialize TinyIPC transport");
+            IsInitialized = false;
+        }
+    }
+
+    private void OnTinyMessageReceived(object sender, TinyMessageReceivedEventArgs e)
+    {
+        if (_disposed) return;
+
+        try
+        {
+            var message = e.Message.ToArray<byte>();
+            MessageReceived?.Invoke(this, new MessageReceivedEventArgs(message));
+        }
+        catch (Exception ex)
+        {
+            PluginLog.Error(ex, "Error processing received message in TinyIPC transport");
+        }
+    }
+
+    public async Task<bool> PublishAsync(byte[] message)
+    {
+        if (!IsInitialized || _disposed) return false;
+
+        try
+        {
+            await _messageBus.PublishAsync(message);
+            return true;
+        }
+        catch (Exception e)
+        {
+            PluginLog.Error(e, "Error publishing message via TinyIPC transport");
+            return false;
+        }
+    }
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+
+        _disposed = true;
+
+        if (_messageBus != null)
+        {
+            _messageBus.MessageReceived -= OnTinyMessageReceived;
+            _messageBus.Dispose();
+        }
+
+        GC.SuppressFinalize(this);
+    }
+}

--- a/Midibard/MidiBard.cs
+++ b/Midibard/MidiBard.cs
@@ -99,6 +99,10 @@ public class MidiBard : IDalamudPlugin
         {
             api.PluginLog.Information("Running on Linux - Unix socket IPC support will be available");
         }
+        else
+        {
+            api.PluginLog.Information("Running on Windows - using native WPF dialogs");
+        }
 
         InstrumentSheet = api.DataManager.Excel.GetSheet<Perform>();
         Instruments = InstrumentSheet!

--- a/Midibard/MidiBard.cs
+++ b/Midibard/MidiBard.cs
@@ -94,6 +94,12 @@ public class MidiBard : IDalamudPlugin
         api.Initialize(this, pi);
         Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
 
+        // System detection for Linux compatibility
+        if (System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Linux))
+        {
+            api.PluginLog.Information("Running on Linux - Unix socket IPC support will be available");
+        }
+
         InstrumentSheet = api.DataManager.Excel.GetSheet<Perform>();
         Instruments = InstrumentSheet!
             .Where(i => !string.IsNullOrWhiteSpace(i.Instrument.ToDalamudString().TextValue) || i.RowId == 0)

--- a/Midibard/MidiBard2.csproj
+++ b/Midibard/MidiBard2.csproj
@@ -6,7 +6,8 @@
         <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
         <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
         <Nullable>disable</Nullable>
-        <UseWpf>true</UseWpf>
+        <UseWpf Condition="'$(OS)' == 'Windows_NT'">true</UseWpf>
+        <DefineConstants Condition="'$(OS)' != 'Windows_NT'">$(DefineConstants);LINUX</DefineConstants>
         <Configurations>Debug;Release;DEBUG2</Configurations>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <Platforms>AnyCPU;x64</Platforms>

--- a/Midibard/UI/FileDialog/FileImport.cs
+++ b/Midibard/UI/FileDialog/FileImport.cs
@@ -41,7 +41,11 @@ public partial class PluginUI
         {
             CheckLastOpenedFolderPath();
 
-            if (MidiBard.config.useLegacyFileDialog)
+            var useLegacyDialog = MidiBard.config.useLegacyFileDialog;
+#if LINUX
+            useLegacyDialog = false; // Force ImGui dialogs on Linux
+#endif
+            if (useLegacyDialog)
                 await RunImportFileTaskWin32Async();
             else
                 await RunImportFileTaskImGuiAsync();
@@ -67,7 +71,11 @@ public partial class PluginUI
         {
             CheckLastOpenedFolderPath();
 
-            if (MidiBard.config.useLegacyFileDialog)
+            var useLegacyDialog = MidiBard.config.useLegacyFileDialog;
+#if LINUX
+            useLegacyDialog = false; // Force ImGui dialogs on Linux
+#endif
+            if (useLegacyDialog)
                 await RunImportFolderTaskWin32Async();
             else
                 await RunImportFolderTaskImGuiAsync();
@@ -87,6 +95,7 @@ public partial class PluginUI
     {
         var tcs = new TaskCompletionSource();
 
+#if !LINUX
         FileDialogs.OpenMidiFileDialog((result, filePaths) =>
         {
             if (result == true && filePaths is { Length: > 0 })
@@ -113,6 +122,10 @@ public partial class PluginUI
                 tcs.TrySetResult();
             }
         });
+#else
+        // On Linux, fall back to ImGui dialogs
+        tcs.SetResult();
+#endif
 
         return tcs.Task;
     }
@@ -169,6 +182,7 @@ public partial class PluginUI
     {
         var tcs = new TaskCompletionSource();
 
+#if !LINUX
         FileDialogs.FolderPicker((result, folderPath) =>
         {
             if (result == true && !string.IsNullOrWhiteSpace(folderPath) && Directory.Exists(folderPath))
@@ -198,6 +212,10 @@ public partial class PluginUI
                 tcs.TrySetResult();
             }
         });
+#else
+        // On Linux, fall back to ImGui dialogs
+        tcs.SetResult();
+#endif
 
         return tcs.Task;
     }

--- a/Midibard/UI/FileDialog/Win32/FileDialogs.cs
+++ b/Midibard/UI/FileDialog/Win32/FileDialogs.cs
@@ -19,12 +19,15 @@ using System;
 using System.IO;
 using System.Threading;
 
+#if !LINUX
 using Microsoft.Win32;
+#endif
 
 using MidiBard2.Resources;
 
 namespace MidiBard.UI.Win32;
 
+#if !LINUX
 static class FileDialogs
 {
     //public delegate void MultiFileSelectedCallback(bool? fileDialogResult, string[] filePaths);
@@ -154,3 +157,4 @@ static class FileDialogs
     }
 
 }
+#endif

--- a/Midibard/UI/FileDialog/Win32/FolderPicker.cs
+++ b/Midibard/UI/FileDialog/Win32/FolderPicker.cs
@@ -19,8 +19,10 @@ using System;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.ComTypes;
+#if !LINUX
 using System.Windows; // for WPF support
 using System.Windows.Interop; // for WPF support
+#endif
 
 namespace MidiBard.UI.Win32;
 
@@ -44,11 +46,13 @@ public class FolderPicker
     }
 
     // for WPF support
+#if !LINUX
     public bool? ShowDialog(Window owner = null, bool throwOnError = false)
     {
         owner ??= Application.Current.MainWindow;
         return ShowDialog(owner != null ? new WindowInteropHelper(owner).Handle : IntPtr.Zero, throwOnError);
     }
+#endif
 
     // for all .NET
     public virtual bool? ShowDialog(IntPtr owner, bool throwOnError = false)

--- a/Midibard/UI/Lyric/LrcEditor.cs
+++ b/Midibard/UI/Lyric/LrcEditor.cs
@@ -176,6 +176,7 @@ public class LrcEditor
             ImGui.SameLine();
             if (ImGui.Button("Open"))
             {
+#if !LINUX
                 FileDialogs.OpenFileDialog((selected, filename, _) =>
                 {
                     if (!selected) return;
@@ -189,6 +190,7 @@ public class LrcEditor
                         PluginLog.Error(e, "error when opening lrc file");
                     }
                 }, LrcFileFilter, false);
+#endif
             }
 
             //ImGui.SameLine();
@@ -516,12 +518,14 @@ public class LrcEditor
 
     private void OpenExportFileDialog(string defalutPath = null)
     {
+#if !LINUX
         FileDialogs.SaveFileDialog((success, filePathToSave) =>
         {
             if (!success) return;
 
             SaveLrc(filePathToSave);
         }, MidiBard.CurrentPlayback?.DisplayName, "All files (*.*)|*.*", "lrc", defalutPath);
+#endif
     }
 
     private void SaveLrc(string filePathToSave)

--- a/Midibard/UI/MusicPlayer/DrawPlaylistMenu.cs
+++ b/Midibard/UI/MusicPlayer/DrawPlaylistMenu.cs
@@ -143,16 +143,21 @@ public partial class PluginUI
             ImGui.MenuItem(shortenPath, false);
 
             var useWin32 = MidiBard.config.useLegacyFileDialog;
+#if LINUX
+            useWin32 = false; // Force ImGui dialogs on Linux
+#endif
             // open playlist
             if (ImGui.MenuItem(Language.menu_label_open_playlist))
             {
                 if (useWin32)
                 {
+#if !LINUX
                     FileDialogs.OpenPlaylistDialog((result, path) =>
                     {
                         if (result != true) return;
                         PlaylistManager.CurrentContainer = PlaylistContainer.FromFile(path);
                     });
+#endif
                 }
                 else
                 {
@@ -174,11 +179,13 @@ public partial class PluginUI
 
                 if (useWin32)
                 {
+#if !LINUX
                     FileDialogs.SavePlaylistDialog((result, path) =>
                     {
                         if (result != true) return;
                         PlaylistManager.CurrentContainer = PlaylistContainer.FromFile(path, true);
                     }, Language.text_new_playlist);
+#endif
                 }
                 else
                 {
@@ -219,11 +226,13 @@ public partial class PluginUI
             {
                 if (useWin32)
                 {
+#if !LINUX
                     FileDialogs.SavePlaylistDialog((result, path) =>
                     {
                         if (result != true) return;
                         PlaylistManager.CurrentContainer.Save(path);
                     }, PlaylistManager.CurrentContainer.DisplayName + Language.text_file_copy);
+#endif
                 }
                 else
                 {
@@ -246,11 +255,13 @@ public partial class PluginUI
                 var playlistSearchString = PlaylistSearchString;
                 if (useWin32)
                 {
+#if !LINUX
                     FileDialogs.SavePlaylistDialog((result, path) =>
                     {
                         if (result != true) return;
                         SaveSearchedPlaylist(path);
                     }, playlistSearchString);
+#endif
                 }
                 else
                 {
@@ -285,11 +296,13 @@ public partial class PluginUI
             {
                 if (useWin32)
                 {
+#if !LINUX
                     FileDialogs.SavePlaylistDialog((result, path) =>
                     {
                         if (result != true) return;
                         PlaylistManager.CurrentContainer.ExportToCsv(path);
                     }, PlaylistManager.CurrentContainer.DisplayName + Language.text_file_copy);
+#endif
                 }
                 else
                 {

--- a/Midibard/Util/Configuration.cs
+++ b/Midibard/Util/Configuration.cs
@@ -68,6 +68,10 @@ public class Configuration : IPluginConfiguration
     public bool StopPlayingWhenEnsembleEnds = true;
     public bool SyncClients = true;
     public bool AutoSetOffAFKSwitchingTime = true;
+
+    // TCP IPC configuration (for Linux/Wine)
+    public int TCPIPCPort = 21043;
+    public string TCPIPCBindAddress = "127.0.0.1";
     public float EnsembleIndicatorDelay = -4;
     public bool UseEnsembleIndicator = false;
     public bool UpdateInstrumentBeforeReadyCheck;

--- a/Midibard/Util/WineDetector.cs
+++ b/Midibard/Util/WineDetector.cs
@@ -1,0 +1,115 @@
+using System;
+using System.Runtime.InteropServices;
+
+using Microsoft.Win32;
+
+using static Dalamud.api;
+
+namespace MidiBard.Util;
+
+public static class WineDetector
+{
+    private static readonly Lazy<bool> _isRunningUnderWine = new(DetectWine);
+    private static readonly Lazy<bool> _isLinuxEnvironment = new(DetectLinux);
+    private static readonly Lazy<string> _wineVersion = new(DetectWineVersion);
+
+    public static bool IsRunningUnderWine => _isRunningUnderWine.Value;
+    public static bool IsLinuxEnvironment => _isLinuxEnvironment.Value;
+    public static string WineVersion => _wineVersion.Value;
+
+    private static bool DetectWine()
+    {
+        try
+        {
+            // Method 1: Check Wine registry key
+            using (var key = Registry.CurrentUser.OpenSubKey(@"Software\Wine"))
+            {
+                if (key != null)
+                {
+                    PluginLog.Information("Wine detected via registry key");
+                    return true;
+                }
+            }
+
+            // Method 2: Check environment variables
+            var winePrefix = Environment.GetEnvironmentVariable("WINEPREFIX");
+            var wine = Environment.GetEnvironmentVariable("WINE");
+
+            if (!string.IsNullOrEmpty(winePrefix) || !string.IsNullOrEmpty(wine))
+            {
+                PluginLog.Information($"Wine detected via environment variables - WINEPREFIX: {winePrefix}, WINE: {wine}");
+                return true;
+            }
+
+            // Method 3: Check process hierarchy (Wine processes often have wine in the name)
+            var currentProcess = System.Diagnostics.Process.GetCurrentProcess();
+            var processName = currentProcess.ProcessName.ToLowerInvariant();
+
+            if (processName.Contains("wine"))
+            {
+                PluginLog.Information("Wine detected via process name");
+                return true;
+            }
+
+            PluginLog.Debug("Wine detection completed - not running under Wine");
+            return false;
+        }
+        catch (Exception e)
+        {
+            PluginLog.Warning(e, "Exception during Wine detection, assuming not Wine");
+            return false;
+        }
+    }
+
+    private static bool DetectLinux()
+    {
+        try
+        {
+            var isLinux = RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
+            PluginLog.Debug($"Linux environment detection: {isLinux}");
+            return isLinux;
+        }
+        catch (Exception e)
+        {
+            PluginLog.Warning(e, "Exception during Linux detection, assuming not Linux");
+            return false;
+        }
+    }
+
+    private static string DetectWineVersion()
+    {
+        try
+        {
+            if (!IsRunningUnderWine) return null;
+
+            // Try to get Wine version from registry
+            using (var key = Registry.CurrentUser.OpenSubKey(@"Software\Wine"))
+            {
+                if (key != null)
+                {
+                    var version = key.GetValue("Version")?.ToString();
+                    if (!string.IsNullOrEmpty(version))
+                    {
+                        PluginLog.Information($"Wine version detected: {version}");
+                        return version;
+                    }
+                }
+            }
+
+            // Try environment variable
+            var wineVersion = Environment.GetEnvironmentVariable("WINE_VERSION");
+            if (!string.IsNullOrEmpty(wineVersion))
+            {
+                PluginLog.Information($"Wine version from environment: {wineVersion}");
+                return wineVersion;
+            }
+
+            return "unknown";
+        }
+        catch (Exception e)
+        {
+            PluginLog.Warning(e, "Exception during Wine version detection");
+            return "unknown";
+        }
+    }
+}


### PR DESCRIPTION
*Not tested in Windows*

I don't have access to a windows box right at the moment, so if unwilling to test, please don't merge. 

Notes:
I did this for my own use, I don't mind if not merged, just thought I'd let upstream know why I forked, but I'm happy to keep this separate. Please just close it if that's the case.

The basic idea is that TinyIPC only works in Windows. It is using memory-mapped-files, but I'm running bard setup in Linux and each client runs in it's own separate wineserver, therefore no shared memory. So I extracted an interface from the existing TinyIPC messaging and added a TCP implementation as a fallback if plugin detects it's running Linux.

The `#if LINUX` bits is just to turn off compilation of WPF bits that are not supported in linux.

