### PR TITLE
fix EnsureValidCids to work like intended

### DIFF
--- a/Midibard/Control/MidiControl/PlaybackInstance/BardPlayback.cs
+++ b/Midibard/Control/MidiControl/PlaybackInstance/BardPlayback.cs
@@ -80,7 +80,6 @@ internal sealed class BardPlayback : Playback
 
     private static MidiFileConfig LoadConfigFallback(TrackInfo[] trackInfos)
     {
-        api.LogDebug("LoadConfigFallback");
         var fallbackMidiFileConfig = MidiFileConfigManager.GetMidiConfigFromTrack(trackInfos);
 
         if (!MidiBard.config.playOnMultipleDevices)
@@ -114,7 +113,6 @@ internal sealed class BardPlayback : Playback
                 midiFileConfig.Tracks[i].AssignedCids.Add(cid);
                 changed = true;
             }
-
         }
 
         if (changed)

--- a/Midibard/Control/MidiControl/PlaybackInstance/BardPlayback.cs
+++ b/Midibard/Control/MidiControl/PlaybackInstance/BardPlayback.cs
@@ -80,6 +80,7 @@ internal sealed class BardPlayback : Playback
 
     private static MidiFileConfig LoadConfigFallback(TrackInfo[] trackInfos)
     {
+        api.LogDebug("LoadConfigFallback");
         var fallbackMidiFileConfig = MidiFileConfigManager.GetMidiConfigFromTrack(trackInfos);
 
         if (!MidiBard.config.playOnMultipleDevices)
@@ -97,25 +98,23 @@ internal sealed class BardPlayback : Playback
 
     private static MidiFileConfig EnsureValidCids(MidiFileConfig midiFileConfig, string filePath)
     {
-        var defaultConfig = LoadDefaultPerformer(midiFileConfig);
+        var defaultConfig = LoadDefaultPerformer(midiFileConfig.JsonClone()); //clone this damn thing :P
         MidiFileConfigManager.UsingDefaultPerformer = false;
 
         bool changed = false;
-
         for (int i = 0; i < midiFileConfig.Tracks.Count; i++)
+            Cids[i] = MidiFileConfig.GetFirstCidInParty(midiFileConfig.Tracks[i]);
+
+        // fall back to default performer if can't find any record in the individual config(caused by changing characters)
+        for (int i = 0; i < defaultConfig.Tracks.Count; i++)
         {
-
-            var cid = MidiFileConfig.GetFirstCidInParty(midiFileConfig.Tracks[i]);
-
-            if (cid <= 0)
+            var cid = MidiFileConfig.GetFirstCidInParty(defaultConfig.Tracks[i]);
+            if (!Cids.Contains(cid))
             {
-                // fall back to default performer if can't find any record in the individual config(caused by changing characters)
-                cid = MidiFileConfig.GetFirstCidInParty(defaultConfig.Tracks[i]);
                 midiFileConfig.Tracks[i].AssignedCids.Add(cid);
                 changed = true;
             }
 
-            Cids[i] = cid;
         }
 
         if (changed)

--- a/Midibard/Managers/MidiFileConfigManager.cs
+++ b/Midibard/Managers/MidiFileConfigManager.cs
@@ -54,7 +54,7 @@ namespace MidiBard.Managers
 
         public static MidiFileConfig? GetMidiConfigFromFile(string songPath)
         {
-            if (songPath.IsNullOrEmpty())
+            if (songPath == null)
                 return null;
             var configFile = GetMidiConfigFileInfo(songPath);
             MidiFileConfig config = null;

--- a/Midibard/UI/Settings/EnsembleTab.cs
+++ b/Midibard/UI/Settings/EnsembleTab.cs
@@ -78,16 +78,16 @@ public partial class PluginUI
             }
             ImGuiUtil.ToolTip("Using File Sharing Services like Google Drive to sync songs and performer settings.");
 
-            ImGuiUtil.Spacing(2);
-            if (ImGui.Checkbox("Ignore Default Performer", ref MidiBard.config.lockTracks))
-            {
-                IPCHandles.SyncAllSettings();
-            }
-            ImGuiUtil.ToolTip("Ignores the default performer settings.");
-
             ImGui.Unindent();
             ImGui.Spacing();
         }
+
+        ImGuiUtil.Spacing(2);
+        if (ImGui.Checkbox("Ignore Default Performer", ref MidiBard.config.lockTracks))
+        {
+            IPCHandles.SyncAllSettings();
+        }
+        ImGuiUtil.ToolTip("Ignores the default performer settings.");
 
         //-------------------
 


### PR DESCRIPTION
LoadDefaultPerformer will overwrite midiFileConfig, just clone it to prent this behavior.
Add the cids to the array and compare it with a second run