### PR TITLE
Add linked ensemble members feature

### DIFF
--- a/Midibard/Configuration/Configuration.cs
+++ b/Midibard/Configuration/Configuration.cs
@@ -29,12 +29,14 @@ using Newtonsoft.Json;
 
 namespace MidiBard;
 
+[Serializable]
 public class Configuration : IPluginConfiguration
 {
     public int Version { get; set; }
 
     [JsonIgnore]
-    public TrackStatus[] TrackStatus = Enumerable.Repeat(new TrackStatus(), 100).ToArray().JsonSerialize().JsonDeserialize<TrackStatus[]>();
+    public TrackStatus[] TrackStatus { get; set; } = Enumerable.Repeat(new TrackStatus(), 100).ToArray();
+
     //public ChannelStatus[] ChannelStatus = Enumerable.Repeat(new ChannelStatus(), 16).ToArray();
     public List<EnsembleMemberConfig> EnsembleMemberConfigs { get; set; } = new();
 
@@ -141,6 +143,55 @@ public class Configuration : IPluginConfiguration
         if (existing == null)
         {
             EnsembleMemberConfigs.Add(newConfig);
+        }
+    }
+
+    public void LinkEnsembleMember(long sourceCid, long targetCid)
+    {
+        var source = EnsembleMemberConfigs.FirstOrDefault(x => x.Cid == sourceCid);
+        var target = EnsembleMemberConfigs.FirstOrDefault(x => x.Cid == targetCid);
+
+        if (source == null || target == null || source == target)
+            return;
+
+        // Move member
+        target.LinkedEnsembleMembers.Add(new EnsembleMember
+        {
+            Cid = source.Cid,
+            Name = source.Name
+        });
+
+        EnsembleMemberConfigs.Remove(source);
+    }
+
+    public void UnlinkEnsembleMember(long parentCid, long linkedCid)
+    {
+        var parent = EnsembleMemberConfigs.FirstOrDefault(x => x.Cid == parentCid);
+
+        if (parent == null)
+            return;
+
+        if (parent.LinkedEnsembleMembers == null || parent.LinkedEnsembleMembers.Count == 0)
+            return;
+
+        var linked = parent.LinkedEnsembleMembers
+            .FirstOrDefault(x => x.Cid == linkedCid);
+
+        if (linked == null)
+            return;
+
+        parent.LinkedEnsembleMembers.Remove(linked);
+
+        // Add back to main list only if not already there
+        if (!EnsembleMemberConfigs.Any(x => x.Cid == linked.Cid))
+        {
+            EnsembleMemberConfigs.Add(new EnsembleMemberConfig
+            {
+                Cid = linked.Cid,
+                Name = linked.Name,
+                TrackAssignmentRegex = "",
+                LinkedEnsembleMembers = new List<EnsembleMember>()
+            });
         }
     }
 

--- a/Midibard/Configuration/ConfigurationTypes.cs
+++ b/Midibard/Configuration/ConfigurationTypes.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 public enum PlayMode
 {
     Single,
@@ -38,11 +40,18 @@ public class TrackStatus
 //    public int Transpose = 0;
 //}
 
+public class EnsembleMember
+{
+    public long Cid;
+    public string Name;
+}
+
 public class EnsembleMemberConfig
 {
     public long Cid;
     public string Name;
     public string TrackAssignmentRegex;
+    public List<EnsembleMember> LinkedEnsembleMembers { get; set; } = new();
 }
 
 public enum ChatType

--- a/Midibard/Control/MidiControl/PlaybackInstance/BardPlayback.cs
+++ b/Midibard/Control/MidiControl/PlaybackInstance/BardPlayback.cs
@@ -120,8 +120,54 @@ internal sealed class BardPlayback : Playback
         MidiFileConfigManager.UsingDefaultPerformer = false;
         for (int i = 0; i < midiFileConfig.Tracks.Count; i++)
             Cids[i] = MidiFileConfig.GetFirstCidInParty(midiFileConfig.Tracks[i]);
+
         return midiFileConfig;
     }
+
+    /*
+        // merge json config with default performer
+        private static MidiFileConfig LoadMidiConfigFromJson(MidiFileConfig midiFileConfig)
+        {
+            var useDefaultPerformerMerge = true;
+            MidiFileConfigManager.UsingDefaultPerformer = false;
+
+            for (int i = 0; i < midiFileConfig.Tracks.Count; i++)
+                Cids[i] = MidiFileConfig.GetFirstCidInParty(midiFileConfig.Tracks[i]);
+
+            // use only json data
+            if (!useDefaultPerformerMerge)
+                return midiFileConfig;
+
+            // merge default performer with json
+            var defaultPerformerFallback = LoadMidiConfigFromDefaultPerformer(midiFileConfig.JsonClone());
+            // bool changed = false;
+
+            for (int i = 0; i < defaultPerformerFallback.Tracks.Count; i++)
+            {
+                var cid = MidiFileConfig.GetFirstCidInParty(defaultPerformerFallback.Tracks[i]);
+
+                if (!Cids.Contains(cid))
+                {
+                    midiFileConfig.Tracks[i].AssignedCids.Add(cid);
+                    // changed = true;
+                }
+            }
+
+            // if (changed)
+            // {
+            //     try
+            //     {
+            //         midiFileConfig.Save(filePath);
+            //     }
+            //     catch
+            //     {
+            //         // ignored
+            //     }
+            // }
+
+            return midiFileConfig;
+        }
+        */
 
     private static MidiFileConfig LoadMidiConfigFromTrackStatus(MidiFileConfig midiConfigFromTrack)
     {

--- a/Midibard/IPC/IPCHandles.cs
+++ b/Midibard/IPC/IPCHandles.cs
@@ -18,7 +18,6 @@
 using System;
 using System.Buffers;
 using System.IO;
-using System.Linq;
 
 using Dalamud.Interface.ImGuiNotification;
 

--- a/Midibard/Managers/MidiFileConfigManager.cs
+++ b/Midibard/Managers/MidiFileConfigManager.cs
@@ -372,26 +372,32 @@ namespace MidiBard.Managers
 
         internal static long GetFirstCidInParty(DbTrack track)
         {
-            long cid = -1;
-
-            foreach (var cur in track.AssignedCids)
+            // main assigned json cids
+            foreach (var assignedCid in track.AssignedCids)
             {
-                foreach (var member in api.PartyList)
-                {
-                    if (member.ContentId == cur)
-                    {
-                        cid = cur;
-                        break;
-                    }
-                }
+                if (api.PartyList.Any(p => p.ContentId == assignedCid))
+                    return assignedCid;
+            }
 
-                if (cid > 0)
+            // linked members
+            foreach (var assignedCid in track.AssignedCids)
+            {
+                var config = MidiBard.config.EnsembleMemberConfigs
+                    .FirstOrDefault(x => x.Cid == assignedCid);
+
+                if (config == null)
+                    continue;
+
+                // check linked in party
+                foreach (var linked in config.LinkedEnsembleMembers)
                 {
-                    break;
+                    if (api.PartyList.Any(p => p.ContentId == linked.Cid))
+                        return linked.Cid;
                 }
             }
 
-            return cid;
+            // nothing match
+            return -1;
         }
     }
 

--- a/Midibard/Resources/Language.resx
+++ b/Midibard/Resources/Language.resx
@@ -127,8 +127,7 @@
             Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
     </resheader>
     <data name="icon button tooltip import file" xml:space="preserve">
-    <value>Import midi file
-Right click to select file dialog type</value>
+    <value>Import midi file</value>
   </data>
     <data name="icon button tooltip import folder" xml:space="preserve">
     <value>Import folder
@@ -320,10 +319,10 @@ Right click to reset visualizer window position</value>
     <value>Following current playback progress</value>
   </data>
     <data name="w32 file dialog" xml:space="preserve">
-    <value>Win32 file dialog</value>
+    <value>Use Win32 file dialog</value>
   </data>
     <data name="imgui file dialog" xml:space="preserve">
-    <value>ImGui file dialog</value>
+    <value>Use ImGui file dialog</value>
   </data>
     <data name="setting label tone mode" xml:space="preserve">
     <value>Tone mode</value>

--- a/Midibard/UI/MusicPlayer/DrawPlaylistMenu.cs
+++ b/Midibard/UI/MusicPlayer/DrawPlaylistMenu.cs
@@ -49,18 +49,18 @@ public partial class PluginUI
         ImGuiUtil.PushIconButtonSize(ImGuiHelpers.ScaledVector2(45.5f, 25));
 
         ImGui.BeginDisabled(IsImportRunning);
-        if (ImGui.BeginPopup("OpenFileDialog_selection"))
-        {
-            if (ImGui.MenuItem(Language.imgui_file_dialog, "", !MidiBard.config.useLegacyFileDialog))
-            {
-                MidiBard.config.useLegacyFileDialog = false;
-            }
-            if (ImGui.MenuItem(Language.w32_file_dialog, "", MidiBard.config.useLegacyFileDialog))
-            {
-                MidiBard.config.useLegacyFileDialog = true;
-            }
-            ImGui.EndPopup();
-        }
+        // if (ImGui.BeginPopup("OpenFileDialog_selection"))
+        // {
+        //     if (ImGui.MenuItem(Language.imgui_file_dialog, "", !MidiBard.config.useLegacyFileDialog))
+        //     {
+        //         MidiBard.config.useLegacyFileDialog = false;
+        //     }
+        //     if (ImGui.MenuItem(Language.w32_file_dialog, "", MidiBard.config.useLegacyFileDialog))
+        //     {
+        //         MidiBard.config.useLegacyFileDialog = true;
+        //     }
+        //     ImGui.EndPopup();
+        // }
 
         ImGui.BeginGroup();
 
@@ -77,7 +77,7 @@ public partial class PluginUI
         }
 
         ImGui.EndGroup();
-        ImGui.OpenPopupOnItemClick("OpenFileDialog_selection", ImGuiPopupFlags.MouseButtonRight);
+        // ImGui.OpenPopupOnItemClick("OpenFileDialog_selection", ImGuiPopupFlags.MouseButtonRight);
         ImGui.EndDisabled();
 
         //-------------------

--- a/Midibard/UI/Settings/DrawSettigsWindow.cs
+++ b/Midibard/UI/Settings/DrawSettigsWindow.cs
@@ -40,7 +40,7 @@ public partial class PluginUI
 
         if (ImGui.BeginTabBar("ConfigTabs"))
         {
-            if (ImGui.BeginTabItem($"{Language.setting_group_label_performance_settings}##GeneralSettingsTab"))
+            if (ImGui.BeginTabItem($"{Language.setting_group_label_general_settings}##GeneralSettingsTab"))
             {
                 DrawGeneralSettings();
                 ImGui.EndTabItem();

--- a/Midibard/UI/Settings/EnsembleTab.cs
+++ b/Midibard/UI/Settings/EnsembleTab.cs
@@ -332,59 +332,6 @@ public partial class PluginUI
         ImGui.End();
     }
 
-    public void LinkMemberTo(long sourceCid, long targetCid)
-    {
-        var source = MidiBard.config.EnsembleMemberConfigs.FirstOrDefault(x => x.Cid == sourceCid);
-        var target = MidiBard.config.EnsembleMemberConfigs.FirstOrDefault(x => x.Cid == targetCid);
-
-        if (source == null || target == null || source == target)
-            return;
-
-        // Move the member
-        target.LinkedEnsembleMembers.Add(new EnsembleMember
-        {
-            Cid = source.Cid,
-            Name = source.Name
-        });
-
-        MidiBard.config.EnsembleMemberConfigs.Remove(source);
-    }
-
-    public void UnlinkMember(long parentCid, long linkedCid)
-    {
-        var parent = MidiBard.config.EnsembleMemberConfigs
-            .FirstOrDefault(x => x.Cid == parentCid);
-
-        if (parent == null)
-            return;
-
-        if (parent.LinkedEnsembleMembers == null || parent.LinkedEnsembleMembers.Count == 0)
-            return;
-
-        var linked = parent.LinkedEnsembleMembers
-            .FirstOrDefault(x => x.Cid == linkedCid);
-
-        if (linked == null)
-            return;
-
-        parent.LinkedEnsembleMembers.Remove(linked);
-
-        // Add back to main list only if not already there
-        if (!MidiBard.config.EnsembleMemberConfigs
-            .Any(x => x.Cid == linked.Cid))
-        {
-            MidiBard.config.EnsembleMemberConfigs.Add(new EnsembleMemberConfig
-            {
-                Cid = linked.Cid,
-                Name = linked.Name,
-                TrackAssignmentRegex = "",
-                LinkedEnsembleMembers = new List<EnsembleMember>()
-            });
-        }
-
-        IPCHandles.SyncAllSettings();
-    }
-
     private void DrawEnsembleMembersSettings()
     {
         if (ImGui.CollapsingHeader(Language.ensemble_party_members, ImGuiTreeNodeFlags.NoAutoOpenOnLog))
@@ -465,7 +412,13 @@ public partial class PluginUI
                         ImGui.TextUnformatted($"{MidiBard.config.EnsembleMemberConfigs[i].LinkedEnsembleMembers[j].Name}");
                         ImGui.SameLine();
                         if (ImGuiUtil.IconButton(FontAwesomeIcon.Unlink, $"##UnlinkEnsembleMemberConfig_{j}", "Unlink Ensemble Member"))
-                            UnlinkMember(MidiBard.config.EnsembleMemberConfigs[i].Cid, MidiBard.config.EnsembleMemberConfigs[i].LinkedEnsembleMembers[j].Cid);
+                        {
+                            MidiBard.config.UnlinkEnsembleMember(
+                                MidiBard.config.EnsembleMemberConfigs[i].Cid,
+                                MidiBard.config.EnsembleMemberConfigs[i].LinkedEnsembleMembers[j].Cid
+                            );
+                            IPCHandles.SyncAllSettings();
+                        }
                     }
                     ImGui.Unindent();
 
@@ -491,7 +444,7 @@ public partial class PluginUI
 
                             if (ImGui.MenuItem(target.Name))
                             {
-                                LinkMemberTo(
+                                MidiBard.config.LinkEnsembleMember(
                                     MidiBard.config.EnsembleMemberConfigs[i].Cid,
                                     target.Cid
                                 );

--- a/Midibard/UI/Settings/EnsembleTab.cs
+++ b/Midibard/UI/Settings/EnsembleTab.cs
@@ -332,6 +332,59 @@ public partial class PluginUI
         ImGui.End();
     }
 
+    public void LinkMemberTo(long sourceCid, long targetCid)
+    {
+        var source = MidiBard.config.EnsembleMemberConfigs.FirstOrDefault(x => x.Cid == sourceCid);
+        var target = MidiBard.config.EnsembleMemberConfigs.FirstOrDefault(x => x.Cid == targetCid);
+
+        if (source == null || target == null || source == target)
+            return;
+
+        // Move the member
+        target.LinkedEnsembleMembers.Add(new EnsembleMember
+        {
+            Cid = source.Cid,
+            Name = source.Name
+        });
+
+        MidiBard.config.EnsembleMemberConfigs.Remove(source);
+    }
+
+    public void UnlinkMember(long parentCid, long linkedCid)
+    {
+        var parent = MidiBard.config.EnsembleMemberConfigs
+            .FirstOrDefault(x => x.Cid == parentCid);
+
+        if (parent == null)
+            return;
+
+        if (parent.LinkedEnsembleMembers == null || parent.LinkedEnsembleMembers.Count == 0)
+            return;
+
+        var linked = parent.LinkedEnsembleMembers
+            .FirstOrDefault(x => x.Cid == linkedCid);
+
+        if (linked == null)
+            return;
+
+        parent.LinkedEnsembleMembers.Remove(linked);
+
+        // Add back to main list only if not already there
+        if (!MidiBard.config.EnsembleMemberConfigs
+            .Any(x => x.Cid == linked.Cid))
+        {
+            MidiBard.config.EnsembleMemberConfigs.Add(new EnsembleMemberConfig
+            {
+                Cid = linked.Cid,
+                Name = linked.Name,
+                TrackAssignmentRegex = "",
+                LinkedEnsembleMembers = new List<EnsembleMember>()
+            });
+        }
+
+        IPCHandles.SyncAllSettings();
+    }
+
     private void DrawEnsembleMembersSettings()
     {
         if (ImGui.CollapsingHeader(Language.ensemble_party_members, ImGuiTreeNodeFlags.NoAutoOpenOnLog))
@@ -340,7 +393,12 @@ public partial class PluginUI
 
             var partyMembers = api.PartyList.Select((partyMember) => partyMember.GetPartyMemberData()).ToList();
             ImGui.TextUnformatted(Language.display_order);
-            ImGuiUtil.HelpMarker("The order used to show bards in the ensemble panel");
+            ImGuiUtil.HelpMarker("""
+            The order used to show bards in the ensemble panel (Drag to reorder)
+
+            Linked members let you automatically apply the same JSON configuration to multiple performers.
+            Any track assigned to the parent member is also assigned to the linked member (handy when you are running  band across different regions)
+            """);
             ImGui.Spacing();
 
             if (ImGui.BeginTable("##EnsembleMemberTable", 3, ImGuiTableFlags.RowBg | ImGuiTableFlags.PadOuterX |
@@ -359,7 +417,6 @@ public partial class PluginUI
 
                     ImGui.TableNextColumn();
                     ImGui.Selectable($"{MidiBard.config.EnsembleMemberConfigs[i].Name}");
-
                     if (ImGui.BeginDragDropSource())
                     {
                         unsafe
@@ -402,7 +459,51 @@ public partial class PluginUI
                     }
                     ImGui.PopStyleColor();
 
+                    ImGui.Indent(20);
+                    for (int j = 0; j < MidiBard.config.EnsembleMemberConfigs[i].LinkedEnsembleMembers.Count; j++)
+                    {
+                        ImGui.TextUnformatted($"{MidiBard.config.EnsembleMemberConfigs[i].LinkedEnsembleMembers[j].Name}");
+                        ImGui.SameLine();
+                        if (ImGuiUtil.IconButton(FontAwesomeIcon.Unlink, $"##UnlinkEnsembleMemberConfig_{j}", "Unlink Ensemble Member"))
+                            UnlinkMember(MidiBard.config.EnsembleMemberConfigs[i].Cid, MidiBard.config.EnsembleMemberConfigs[i].LinkedEnsembleMembers[j].Cid);
+                    }
+                    ImGui.Unindent();
+
                     ImGui.TableNextColumn();
+
+                    bool isLinkDisabled = MidiBard.config.EnsembleMemberConfigs[i].LinkedEnsembleMembers.Count != 0;
+                    ImGui.BeginDisabled(isLinkDisabled);
+                    if (ImGuiUtil.IconButton(FontAwesomeIcon.Link, $"##LinkEnsembleMemberConfig_{i}", "Link Ensemble Member"))
+                    {
+                        ImGui.OpenPopup($"LinkEnsembleMember");
+                    }
+
+                    if (ImGui.BeginPopup($"LinkEnsembleMember"))
+                    {
+                        ImGui.TextUnformatted("Associate with:");
+                        ImGui.Separator();
+
+                        for (int t = 0; t < MidiBard.config.EnsembleMemberConfigs.Count; t++)
+                        {
+                            if (t == i) continue; // cannot link to itself
+
+                            var target = MidiBard.config.EnsembleMemberConfigs[t];
+
+                            if (ImGui.MenuItem(target.Name))
+                            {
+                                LinkMemberTo(
+                                    MidiBard.config.EnsembleMemberConfigs[i].Cid,
+                                    target.Cid
+                                );
+                                IPCHandles.SyncAllSettings();
+                            }
+                        }
+
+                        ImGui.EndPopup();
+                    }
+                    ImGui.EndDisabled();
+
+                    ImGui.SameLine();
                     if (ImGui.Button($"↑##MoveUpEnsembleMemberConfig_{i}"))
                         MidiBard.config.EnsembleMemberConfigs.MoveItemToIndex(i, i - 1);
 
@@ -411,7 +512,7 @@ public partial class PluginUI
                         MidiBard.config.EnsembleMemberConfigs.MoveItemToIndex(i, i + 1);
 
                     ImGui.SameLine();
-                    if (ImGuiUtil.IconButton(FontAwesomeIcon.TrashAlt, $" X ##RemoveEnsembleMemberConfig_{i}", "Delete"))
+                    if (ImGuiUtil.IconButton(FontAwesomeIcon.TrashAlt, $"##RemoveEnsembleMemberConfig_{i}", "Delete"))
                         MidiBard.config.EnsembleMemberConfigs.SafeRemoveAt(i);
 
                     ImGui.PopID();
@@ -423,8 +524,7 @@ public partial class PluginUI
             ImGui.Spacing();
             ImGui.Spacing();
 
-            bool allPartyMembersInConfig = partyMembers.All(partyMember =>
-                MidiBard.config.EnsembleMemberConfigs?.Any(config => config.Cid == partyMember.Cid) ?? false);
+            bool allPartyMembersInConfig = partyMembers.All(partyMember => ContainsCidDeep(MidiBard.config.EnsembleMemberConfigs, partyMember.Cid));
 
             ImGui.BeginDisabled(allPartyMembersInConfig);
             ImGui.TextUnformatted(Language.available_party_members);
@@ -432,13 +532,21 @@ public partial class PluginUI
             {
                 foreach (var partyMember in partyMembers)
                 {
-                    var isCidInConfigList = MidiBard.config.EnsembleMemberConfigs?.Any(p => p.Cid == partyMember.Cid) ?? false;
-                    if (!isCidInConfigList)
+                    bool isCidUsed = ContainsCidDeep(MidiBard.config.EnsembleMemberConfigs, partyMember.Cid);
+                    if (!isCidUsed)
                     {
                         var playerInfo = $"{partyMember.Name}@{partyMember.World}";
                         if (ImGui.Selectable($"{playerInfo}##{partyMember.Cid}", false))
                         {
-                            MidiBard.config.AddEnsembleMemberConfig(new EnsembleMemberConfig { Cid = partyMember.Cid, Name = playerInfo, TrackAssignmentRegex = "" });
+                            var newMember = new EnsembleMemberConfig
+                            {
+                                Cid = partyMember.Cid,
+                                Name = playerInfo,
+                                TrackAssignmentRegex = "",
+                                LinkedEnsembleMembers = new()
+                            };
+
+                            MidiBard.config.AddEnsembleMemberConfig(newMember);
                             IPCHandles.SyncAllSettings();
                         }
                     }
@@ -448,5 +556,21 @@ public partial class PluginUI
             ImGui.EndDisabled();
             ImGui.Unindent();
         }
+    }
+
+    public static bool ContainsCidDeep(
+    List<EnsembleMemberConfig> list,
+    long cid)
+    {
+        foreach (var config in list)
+        {
+            if (config.Cid == cid)
+                return true;
+
+            if (config.LinkedEnsembleMembers?.Any(m => m.Cid == cid) ?? false)
+                return true;
+        }
+
+        return false;
     }
 }

--- a/Midibard/UI/Settings/GeneralTab.cs
+++ b/Midibard/UI/Settings/GeneralTab.cs
@@ -81,6 +81,13 @@ public partial class PluginUI
 
             //-------------------
 
+            if (ImGui.Checkbox(Language.w32_file_dialog, ref MidiBard.config.useLegacyFileDialog))
+            {
+                IPCHandles.SyncAllSettings();
+            }
+
+            //-------------------
+
             //Checkbox(Low_latency_mode, ref MidiBard.config.LowLatencyMode);
             //ImGuiUtil.ToolTip(low_latency_mode_tooltip);
 

--- a/Midibard/UI/Settings/PerformanceTab.cs
+++ b/Midibard/UI/Settings/PerformanceTab.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Numerics;
 using System.Text.RegularExpressions;
 

--- a/Midibard/Util/Extensions/Extensions.cs
+++ b/Midibard/Util/Extensions/Extensions.cs
@@ -37,7 +37,11 @@ namespace MidiBard.Util;
 
 static class Extensions
 {
-    private static readonly JsonSerializerSettings JsonSerializerSettings = new JsonSerializerSettings() { TypeNameHandling = TypeNameHandling.None, TypeNameAssemblyFormatHandling = TypeNameAssemblyFormatHandling.Simple };
+    private static readonly JsonSerializerSettings JsonSerializerSettings = new JsonSerializerSettings()
+    {
+        TypeNameHandling = TypeNameHandling.None,
+        TypeNameAssemblyFormatHandling = TypeNameAssemblyFormatHandling.Simple,
+    };
 
     internal static bool ContainsIgnoreCase(this string haystack, string needle)
     {


### PR DESCRIPTION
 - Add linked ensemble members feature, now you only need to assign the JSON config once, the other members will automatically match it when you’re on a datacenter in another region
 - Add an option to choose the dialog version type (Win32 or ImGui). Right now it’s a bit hidden, since you can only access it with a right-click